### PR TITLE
Update to use DefaultAzureCredential

### DIFF
--- a/functions/DpsAdtAllocationFunc.cs
+++ b/functions/DpsAdtAllocationFunc.cs
@@ -97,14 +97,8 @@ namespace Samples.AdtIothub
         public static async Task<string> FindOrCreateTwinAsync(string dtmi, string regId, ILogger log)
         {
             // Create Digital Twins client
-            var cred = new ManagedIdentityCredential(adtAppId);
-            var client = new DigitalTwinsClient(
-                new Uri(adtInstanceUrl),
-                cred,
-                new DigitalTwinsClientOptions
-                {
-                    Transport = new HttpClientTransport(singletonHttpClientInstance)
-                });
+            var cred = new DefaultAzureCredential();
+            var client = new DigitalTwinsClient(new Uri(adtInstanceUrl), cred);
 
             // Find existing DigitalTwin with registration ID
             try

--- a/functions/DpsAdtAllocationFunc.cs
+++ b/functions/DpsAdtAllocationFunc.cs
@@ -23,7 +23,6 @@ namespace Samples.AdtIothub
 {
     public static class DpsAdtAllocationFunc
     {
-        private const string adtAppId = "https://digitaltwins.azure.net";
         private static string adtInstanceUrl = Environment.GetEnvironmentVariable("ADT_SERVICE_URL");
         private static readonly HttpClient singletonHttpClientInstance = new HttpClient();
 


### PR DESCRIPTION
Azure.Identity has suggested that for sample code we encourage the use of DefaultAzureCredential, which wraps ManagedIdentityCredential and other credential methods in a chained fashion (so adjusting to this credential method shouldn't be a functional change when deployed to a cloud service--but has unblocked users that have experienced "ManagedIdentityCredential authentication failed" error).

Related issues:
* https://github.com/MicrosoftDocs/azure-docs/issues/92112
* https://learn.microsoft.com/en-us/answers/questions/828999/app-throws-error-managedidentitycredential-authent.html